### PR TITLE
Fix/clear zombie captures on startup

### DIFF
--- a/bin/capture_manager.py
+++ b/bin/capture_manager.py
@@ -25,6 +25,14 @@ class CaptureManager(AbstractManager):
         self.captures: set[Task[None]] = set()
         self.lacus = Lacus()
 
+    def _clear_ongoing_on_startup(self) -> None:
+        # At process start, self.captures is empty — no task can be running.
+        # Any UUID left in lacus:ongoing is a zombie from a previous crash.
+        zombie_count = self.lacus.redis.zcard('lacus:ongoing')
+        if zombie_count:
+            self.logger.warning(f'Startup cleanup: clearing {zombie_count} zombie capture(s) from lacus:ongoing')
+            self.lacus.redis.delete('lacus:ongoing')
+
     async def clear_dead_captures(self) -> None:
         ongoing = {capture.get_name(): capture for capture in self.captures}
         max_capture_time = get_config('generic', 'max_capture_time')
@@ -82,6 +90,10 @@ def main() -> None:
     loop.add_signal_handler(signal.SIGTERM, lambda: loop.create_task(p.stop_async()))
 
     try:
+        # Flush stale captures before the event loop starts.
+        # Valkey persists across container restarts, so lacus:ongoing
+        # may contain UUIDs from a process that was killed mid-capture.
+        p._clear_ongoing_on_startup()
         loop.run_until_complete(p.run_async(sleep_in_sec=1))
     finally:
         loop.close()

--- a/bin/capture_manager.py
+++ b/bin/capture_manager.py
@@ -55,6 +55,11 @@ class CaptureManager(AbstractManager):
                         if not capture.done():
                             self.logger.error(f'{expected_uuid} is not done after canceling, trying {max_cancel} more times.')
                             await asyncio.sleep(1)
+                # All cancel attempts exhausted but the task is still stuck.
+                # Free the Redis slot so new captures aren't blocked.
+                if not capture.done():
+                    self.logger.error(f'{expected_uuid} could not be canceled after 5 attempts, force-clearing from Redis.')
+                    self.lacus.core.clear_capture(expected_uuid, 'Force-cleared: task could not be canceled.')
 
     async def _to_run_forever_async(self) -> None:
 

--- a/bin/capture_manager.py
+++ b/bin/capture_manager.py
@@ -28,10 +28,13 @@ class CaptureManager(AbstractManager):
     def _clear_ongoing_on_startup(self) -> None:
         # At process start, self.captures is empty — no task can be running.
         # Any UUID left in lacus:ongoing is a zombie from a previous crash.
-        zombie_count = self.lacus.redis.zcard('lacus:ongoing')
-        if zombie_count:
-            self.logger.warning(f'Startup cleanup: clearing {zombie_count} zombie capture(s) from lacus:ongoing')
-            self.lacus.redis.delete('lacus:ongoing')
+        # Use clear_capture() per UUID so each gets a proper error result
+        # and capture_settings are cleaned up.
+        ongoing = self.lacus.monitoring.get_ongoing_captures()
+        if ongoing:
+            self.logger.warning(f'Startup cleanup: clearing {len(ongoing)} zombie capture(s) from lacus:ongoing')
+            for uuid, _ in ongoing:
+                self.lacus.core.clear_capture(uuid, 'Cleared on startup: previous process died.')
 
     async def clear_dead_captures(self) -> None:
         ongoing = {capture.get_name(): capture for capture in self.captures}
@@ -60,6 +63,7 @@ class CaptureManager(AbstractManager):
                 if not capture.done():
                     self.logger.error(f'{expected_uuid} could not be canceled after 5 attempts, force-clearing from Redis.')
                     self.lacus.core.clear_capture(expected_uuid, 'Force-cleared: task could not be canceled.')
+                    self.captures.discard(capture)
 
     async def _to_run_forever_async(self) -> None:
 


### PR DESCRIPTION
First of all, thank you very much for opening a pull request in this repository.

In order for us to review your changes prior merging them, please makes sure it follows the rules below (if relevant):
* no reformatting changing the line length globally
* make multiple PRs if you're changing multiple things

What kind of change does this PR introduce?

* [x] Bugfix
* [ ] New Feature
* [ ] Code style update (formatting, local variables)

 **NOTE**: if you used black or any other code formatting tool, we will only accept one change per Pull Request.
           Do not attempt to "fix" everything in a single PR, as it makes reviewing the changes extremely difficult to review.
           If the fix is related to the length of the lines, it will be rejected.

* [ ] Refactoring (no functional changes, no API changes)
* [ ] CI-related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other - please describe extensively what it does

If you're using an AI to assist you in generating this PR, please review the changes extensively and make sure they are accurate and useful.
Once it is the case, please tick the box below.

* [x] I used an AI to generate this PR and made sure I'm not wasting the time of the reviewer.

## What does it do?

Fixes zombie captures permanently blocking `concurrent_captures` slots after a container restart (or any unclean `capture_manager` shutdown).

## The problem

```
  Normal operation:
  ┌──────────────────┐         ┌───────────────────┐
  │ capture_manager  │         │  Valkey (Redis)    │
  │                  │         │                    │
  │  self.captures:  │ zadd    │  lacus:ongoing:    │
  │   {task_A,       │────────►│   uuid_A (t=100)   │
  │    task_B}       │         │   uuid_B (t=101)   │
  │                  │ zrem    │                    │
  │  finally: ───────│────────►│  (removed on done) │
  └──────────────────┘         └───────────────────┘
          ✓ in sync                  ✓ in sync

  After kill/restart:
  ┌──────────────────┐         ┌───────────────────┐
  │ capture_manager  │         │  Valkey (Redis)    │
  │  (new process)   │         │  (persisted data)  │
  │                  │         │                    │
  │  self.captures:  │         │  lacus:ongoing:    │
  │   {} (empty)     │  !=     │   uuid_A (t=100)   │  ◄── zombie
  │                  │         │   uuid_B (t=101)   │  ◄── zombie
  │                  │         │   ...              │
  │  finally: never  │         │   uuid_H (t=108)   │  ◄── zombie
  │  ran on old proc │         │                    │
  └──────────────────┘         └───────────────────┘
     0 real tasks              8 slots blocked
                               concurrent_captures = 8
                               → no new captures can start
```

When `capture_manager` is killed (SIGKILL, OOM, `docker restart`) while captures are in-flight, the `finally` blocks in `LacusCore._capture()` never execute. The UUIDs remain in the `lacus:ongoing` Redis sorted set because Valkey persists to disk and reloads on restart.

On the next startup, the new `capture_manager` process has an empty `self.captures` task set, but `lacus:ongoing` is full of stale UUIDs from the dead process. These zombie entries occupy `concurrent_captures` slots.

The existing `clear_dead_captures()` method does detect orphaned UUIDs (in Redis but not in the task set), but it has a safety window -it won't clear a capture if `start_time > time.time() - max_capture_time * 1.1`. During this window, zombie UUIDs block all slots and no new captures can start.

With `concurrent_captures=8` and `max_capture_time=90`, that's **~99 seconds of zero capture throughput** after every restart.

## Reproduction

```bash
# With captures actively running, restart the container:
docker restart lacus

# Immediately check Redis:
valkey-cli -s /app/lacus/cache/cache.sock ZCARD lacus:ongoing
# Returns: 8 (all zombies -no real tasks exist in the new process)

# All concurrent_captures slots are blocked until max_capture_time * 1.1 elapses.
```

## The fix

**Commit 840a018 -Startup cleanup** (`_clear_ongoing_on_startup`)

When `capture_manager` starts, `self.captures` is empty -no capture task can possibly be running. Any UUID in `lacus:ongoing` is by definition a zombie. The fix flushes the sorted set before the event loop starts.

This is safe because:
- `capture_manager` is single-process -only one instance runs per container
- The `website` process (Gunicorn) only reads from `lacus:ongoing`, never writes to it
- The only writer is `LacusCore._capture()`, which runs inside `capture_manager`'s event loop

**Commit 83027ce -Force-clear after failed cancellation**

When a Playwright subprocess hangs and `task.cancel()` doesn't propagate (browser process ignores the `CancelledError`), the existing code retries cancellation 5 times, then logs an error but leaves the UUID in Redis -permanently blocking the slot. The fix calls `clear_capture()` after exhausting all cancel attempts.

## Testing

### 1. Reproduce the bug (before fix)

```bash
# Confirm captures are actively running:
docker exec lacus valkey-cli -s /app/lacus/cache/cache.sock ZCARD lacus:ongoing
# → 8

# Restart the container (Valkey persists to disk):
docker restart lacus
sleep 15

# Check Redis -all slots blocked by zombies:
docker exec lacus valkey-cli -s /app/lacus/cache/cache.sock ZCARD lacus:ongoing
# → 8 (all zombies -new process has zero real tasks)

# Verify these are stale UUIDs with old timestamps:
docker exec lacus valkey-cli -s /app/lacus/cache/cache.sock ZRANGE lacus:ongoing 0 -1 WITHSCORES
# → timestamps from before the restart
```

### 2. Apply the fix

```bash
# Copy patched capture_manager.py into the container:
docker cp capture_manager.py lacus:/app/lacus/bin/capture_manager.py
```

### 3. Inject zombies and verify cleanup

```bash
# Inject 8 fake zombie UUIDs into Redis:
for i in $(seq 1 8); do
  docker exec lacus valkey-cli -s /app/lacus/cache/cache.sock \
    ZADD lacus:ongoing 1774000000 "zombie-$(printf '%04d' $i)-0000-0000-000000000000"
done

# Confirm they're there:
docker exec lacus valkey-cli -s /app/lacus/cache/cache.sock ZCARD lacus:ongoing
# → 8+ (zombies + any real captures)

# Restart with patched code:
docker restart lacus
sleep 15

# Check the log -startup cleanup should fire:
docker logs lacus 2>&1 | grep "Startup cleanup"
# → "Startup cleanup: clearing 8 zombie capture(s) from lacus:ongoing"

# Confirm zero zombie UUIDs remain:
docker exec lacus valkey-cli -s /app/lacus/cache/cache.sock \
  ZRANGE lacus:ongoing 0 -1 | grep -c zombie
# → 0

# Verify fresh captures are running (new timestamps):
docker exec lacus valkey-cli -s /app/lacus/cache/cache.sock ZRANGE lacus:ongoing 0 -1 WITHSCORES
# → only UUIDs with timestamps from after the restart
```
